### PR TITLE
compileSdkVersion and buildToolVersion updated

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'com.android.application'
 apply plugin: 'com.google.gms.google-services'
 
 android {
-    compileSdkVersion 'Google Inc.:Google APIs:21'
-    buildToolsVersion "22.0.1"
+    compileSdkVersion 21
+    buildToolsVersion "25.0.0"
 
     defaultConfig {
         applicationId "com.ap.collegespacev2"


### PR DESCRIPTION
compileSdkVersion changed from 'Google Inc.:Google APIs:21' to 21 and buildToolVersion from "22.0.1" to "25.0.0"
to make the app runnable in android studio after the latest update